### PR TITLE
Use local path instead of absolute

### DIFF
--- a/addons/freecam_3D/plugin.gd
+++ b/addons/freecam_3D/plugin.gd
@@ -11,8 +11,8 @@ func _enter_tree() -> void:
 	add_custom_type(
 			"Freecam3D", 
 			"Camera3D", 
-			preload("res://addons/freecam_3D/freecam.gd"), 
-			preload("res://addons/freecam_3D/mc-camera2.png"))
+			preload("freecam.gd"), 
+			preload("mc-camera2.png"))
 
 
 func _exit_tree() -> void:


### PR DESCRIPTION
Changed plugin.gd to use the local path to freecam.gd and mc-camera2.png instead of the absolute path from res:://. This allows users to change the name of the addon folder.